### PR TITLE
Edited the recipe and the prerequisites of the pdf of the resume.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-.PHONY: build clean resume
+.PHONY:  clean resume
 
-TEX_FILE := AmrAbed.tex
+RESUME := AmrAbed
 
-build:
-	docker compose run latexmk $(TEX_FILE)
-
+%.pdf: %.tex sections/*
+	docker compose run latexmk $<
+	docker compose down && docker container prune -f && docker rmi latexmk
 clean:
 	rm -f *.aux *.log *.out *.bbl *.blg *.fls *.fdb_latexmk  # workaroud since the -c option is not working
-	docker compose down && docker container prune -f && docker rmi latexmk
 
-resume: build clean
+
+resume: $(RESUME).pdf


### PR DESCRIPTION
_Note_: prerequisites is mandatory in order to make the `make` detect the changes of the sections' files and the main file.

In the old Makefile, there were no prerequisites defined, so the `make resume` command always build the resume even if there is no change in the `sections/*` nor `AmrAbed.tex`